### PR TITLE
Fix missing history file error

### DIFF
--- a/src/main/java/com/victor/coffee/ReceiptManager.java
+++ b/src/main/java/com/victor/coffee/ReceiptManager.java
@@ -1,6 +1,8 @@
 package com.victor.coffee;
 
 import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -41,6 +43,11 @@ public class ReceiptManager {
 
     public List<String> readAllReceipts() {
         List<String> lines = new ArrayList<>();
+
+        if (!Files.exists(Paths.get(HISTORY_FILE))) {
+            return lines;
+        }
+
         try (BufferedReader reader = new BufferedReader(new FileReader(HISTORY_FILE))) {
             StringBuilder currentReceipt = new StringBuilder();
             String line;


### PR DESCRIPTION
Avoids showing an error message when the history file does not exist. If the file is missing, the method now returns an empty list instead of printing an exception message. This ensures a cleaner user experience during first-time app usage.